### PR TITLE
Disable keyword style, so that identifiers like :: are accepted

### DIFF
--- a/abnf.egg
+++ b/abnf.egg
@@ -6,7 +6,8 @@
  (dependencies srfi-1 utf8 lexgen) 
  (test-dependencies test)
  (author "Ivan Raikov")
- (components (extension abnf)
+ (components (extension abnf
+                        (csc-options "-keyword-style" "none"))
              (extension abnf-consumers
                         (component-dependencies abnf)))
  )


### PR DESCRIPTION
In older CHICKENs, keywords could be bound like regular symbols, which
was a bit of a strange behaviour.  In 5.0.2 and later this no longer
works, so we'll need to either quote the symbols using pipe characters
or disable the keyword style reader.

Given that this code doesn't seem to use keywords at all, simply
disabling the reader for keyword is the simplest fix.